### PR TITLE
[BUG] Properties of Event are optional in V1.2

### DIFF
--- a/src/config/validation/schema-rules.js
+++ b/src/config/validation/schema-rules.js
@@ -479,7 +479,7 @@ export default [
         getInvalid: (els, doc) => getMoreThanOne(els, doc, "has-event-code"),
         prio: "MUST",
         spec: "https://iirds.org/fileadmin/iiRDS_specification/20231110-1.2-release/index.html#information-units:~:text=Instances%20of%20the%20iirds%3AEvent%20class%20MUST%20have%20the%20following%20properties%3A%20iirds%3AeventCode%20and%20iirds%3AeventType.",
-        version: ["V1.0", "V1.0.1", "V1.1", "V1.2"],
+        version: ["V1.0", "V1.0.1", "V1.1"],
         rule: {
             "de": "Instanzen der Klasse iirds:Event MÜSSEN die Eigenschaft iirds:eventCode haben",
             "en": "Instances of the iirds:Event class MUST have property iirds:eventCode"
@@ -488,11 +488,11 @@ export default [
     {
         id: "M16.2",
         path: "Event",
-        assert: els => els.filter(el => !el.querySelectorAll("has-event-code")),
-        getInvalid: els => els.filter(el => !el.querySelectorAll("has-event-code")),
+        assert: els => els.filter(el => !el.querySelectorAll("has-event-type")),
+        getInvalid: els => els.filter(el => !el.querySelectorAll("has-event-type")),
         prio: "MUST",
         spec: "https://iirds.org/fileadmin/iiRDS_specification/20231110-1.2-release/index.html#information-units:~:text=Instances%20of%20the%20iirds%3AEvent%20class%20MUST%20have%20the%20following%20properties%3A%20iirds%3AeventCode%20and%20iirds%3AeventType.",
-        version: ["V1.0", "V1.0.1", "V1.1", "V1.2"],
+        version: ["V1.0", "V1.0.1", "V1.1"],
         rule: {
             "de": "Instanzen der Klasse iirds:Event MÜSSEN die Eigenschaft iirds:eventType haben",
             "en": "Instances of the iirds:Event class MUST have property iirds:eventType"

--- a/src/util/validator-schema.js
+++ b/src/util/validator-schema.js
@@ -20,7 +20,10 @@ export default {
         const document = Parser.parseFromString(processedString, documentMimeType);
         const iiRDSVersion = document.querySelector("iiRDSVersion")?.textContent;
 
-        const scopedTests = validations.filter(v => v.assert).filter(v => !prio || v.prio === prio);
+        const scopedTests = validations
+            .filter(v => v.assert)
+            .filter(v => !prio || v.prio === prio)
+            .filter(v => v.version.includes("V" + iiRDSVersion));
         const checkedSchemaRules = scopedTests.length;
         for (let test of scopedTests) {
             const selection = Array.from(document.querySelectorAll(test.path));


### PR DESCRIPTION
:rocket: **Anpassungen**

- mit 1.2 sind die Properties der Klasse Event optional und werden nicht mehr geprüft, wenn die Version im Paket 1.2 ist
